### PR TITLE
Fix silent slide-build failures in CI

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - "2026"
-      # Temporary: validate the build on this CI fix branch (no release is created
-      # because the create_release job is guarded by refs/heads/2026). Remove on merge.
-      - "ci/fix-slide-build"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,12 +16,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Diagnose slide build (temporary)
-        shell: pwsh
-        continue-on-error: true
-        run: |
-          pandoc -f markdown+smart+yaml_metadata_block+rebase_relative_paths --slide-level 2 -t beamer -H preamble.tex -F pandoc-plantuml -o diag.tex Material/Slides/01_Vorstellung_Intro.md
-          lualatex -interaction=nonstopmode -halt-on-error diag.tex 2>&1 | Select-String -Pattern "! |not found|metropolis|fatal|Emergency" -Context 1,3
       - name: Build PDFs
         shell: pwsh
         run: ./build.ps1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "2026"
+      # Temporary: validate the build on this CI fix branch (no release is created
+      # because the create_release job is guarded by refs/heads/2026). Remove on merge.
+      - "ci/fix-slide-build"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,6 +16,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Diagnose slide build (temporary)
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          pandoc -f markdown+smart+yaml_metadata_block+rebase_relative_paths --slide-level 2 -t beamer -H preamble.tex -F pandoc-plantuml -o diag.tex Material/Slides/01_Vorstellung_Intro.md
+          lualatex -interaction=nonstopmode -halt-on-error diag.tex 2>&1 | Select-String -Pattern "! |not found|metropolis|fatal|Emergency" -Context 1,3
       - name: Build PDFs
         shell: pwsh
         run: ./build.ps1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,7 +18,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Install slide beamer theme
         shell: pwsh
-        run: tlmgr install beamertheme-metropolis pgfopts
+        # The container ships TeX Live 2024; tlmgr's default mirror is the current
+        # release and refuses cross-release installs, so pin the 2024 historic repo.
+        # metropolis pulls in pgfopts and defaults to the Fira fonts.
+        run: |
+          tlmgr option repository https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2024/tlnet-final
+          tlmgr install beamertheme-metropolis pgfopts fira
       - name: Build PDFs
         shell: pwsh
         run: ./build.ps1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Install slide beamer theme
+        shell: pwsh
+        run: tlmgr install beamertheme-metropolis pgfopts
       - name: Build PDFs
         shell: pwsh
         run: ./build.ps1

--- a/build.ps1
+++ b/build.ps1
@@ -29,35 +29,53 @@ $targets = foreach ($arg in $files) {
   }
 }
 
-# Build PDFs in parallel, but throttle concurrency: unbounded parallel lualatex
-# (especially the heavy beamer slide decks) exhausts memory on CI runners and the
-# processes get killed, silently producing no output.
+# Build PDFs in parallel, but throttle concurrency to keep peak load on CI
+# runners reasonable. Each worker captures pandoc's full output and exit code
+# into its result object instead of writing to the console: parallel runspaces
+# interleave their output unreadably, so we emit one clean, ordered report
+# afterwards in the main thread.
 $results = $targets | ForEach-Object -ThrottleLimit 2 -Parallel {
   # Parallel runspaces do not reliably inherit the caller's location.
   Set-Location $using:currentDir
   $t = $_
 
-  if ($t.Type -eq "Slides") {
-    Write-Host "Building slides for $($t.Source)"
-    pandoc -f markdown+smart+yaml_metadata_block+rebase_relative_paths --toc --slide-level 2 --number-section --pdf-engine lualatex -t beamer -H preamble.tex -F pandoc-plantuml -o $t.Pdf $t.Source
+  try {
+    if ($t.Type -eq "Slides") {
+      $log = pandoc -f markdown+smart+yaml_metadata_block+rebase_relative_paths --toc --slide-level 2 --number-section --pdf-engine lualatex -t beamer -H preamble.tex -F pandoc-plantuml -o $t.Pdf $t.Source 2>&1 | Out-String
+    }
+    else {
+      $log = pandoc -f markdown+smart+yaml_metadata_block+rebase_relative_paths --toc --toc-depth 1 --number-section --pdf-engine lualatex -F pandoc-plantuml -o $t.Pdf $t.Source 2>&1 | Out-String
+    }
+    $code = $LASTEXITCODE
   }
-  else {
-    Write-Host "Building document for $($t.Source)"
-    pandoc -f markdown+smart+yaml_metadata_block+rebase_relative_paths --toc --toc-depth 1 --number-section --pdf-engine lualatex -F pandoc-plantuml -o $t.Pdf $t.Source
+  catch {
+    $log = ($_ | Out-String)
+    $code = 1
   }
 
   [PSCustomObject]@{
     Pdf      = $t.Pdf
-    ExitCode = $LASTEXITCODE
+    Source   = $t.Source
+    ExitCode = $code
+    Ok       = ($code -eq 0 -and (Test-Path $t.Pdf))
+    Log      = $log
   }
 }
 
+# Emit an ordered status line per file so the build log is readable.
+foreach ($r in ($results | Sort-Object Pdf)) {
+  if ($r.Ok) { Write-Host "OK    $($r.Pdf)" }
+  else { Write-Host "FAIL  $($r.Pdf) (exit code $($r.ExitCode))" }
+}
+
 # Fail the build if any PDF did not compile, instead of silently shipping a
-# partial result.
-$failed = $results | Where-Object { $_.ExitCode -ne 0 -or -not (Test-Path $_.Pdf) }
+# partial result. Print the captured pandoc/LaTeX output for each failure.
+$failed = $results | Where-Object { -not $_.Ok }
 if ($failed) {
-  Write-Host "##[error]The following PDF builds failed:"
-  $failed | ForEach-Object { Write-Host " - $($_.Pdf) (exit code $($_.ExitCode))" }
+  foreach ($r in $failed) {
+    Write-Host "##[error]Build failed for $($r.Source) -> $($r.Pdf) (exit code $($r.ExitCode))"
+    Write-Host $r.Log
+  }
   exit 1
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -10,32 +10,56 @@ else {
   $zip = 1
 }
 
-$jobs = @()
-
 Write-Host "Building PDFs for the following files:"
 foreach ($arg in $files) {
   Write-Host "- $arg"
 }
 
 
-foreach ($arg in $files) {
-  $pdfName = "build/" + ((Get-Item $arg).Directory.Basename) + "/" + ((Get-Item $arg).Basename) + ".pdf"
+# Pre-compute targets and create output directories in the main thread to avoid
+# races between parallel workers creating the same directory.
+$targets = foreach ($arg in $files) {
+  $item = Get-Item $arg
+  $pdfName = "build/" + $item.Directory.BaseName + "/" + $item.BaseName + ".pdf"
   New-Item -ItemType Directory -Path (Split-Path $pdfName) -Force > $null
-
-  $jobs += Start-Job -ScriptBlock { 
-    param($arg, $pdfName)
-    $pdfType = (Get-ChildItem $arg).Directory.Name
-    if ($pdfType -eq "Slides") {
-      Write-Host "Building slides for $arg"
-      pandoc -f markdown+smart+yaml_metadata_block+rebase_relative_paths --toc --slide-level 2 --number-section --pdf-engine lualatex -t beamer -H preamble.tex -F pandoc-plantuml -o $pdfName $arg
-    }
-    else {
-      pandoc -f markdown+smart+yaml_metadata_block+rebase_relative_paths --toc --toc-depth 1 --number-section --pdf-engine lualatex -F pandoc-plantuml -o $pdfName $arg
-    }
-  } -ArgumentList $arg, $pdfName
+  [PSCustomObject]@{
+    Source = $item.FullName
+    Pdf    = $pdfName
+    Type   = $item.Directory.Name
+  }
 }
 
-Wait-Job $jobs
+# Build PDFs in parallel, but throttle concurrency: unbounded parallel lualatex
+# (especially the heavy beamer slide decks) exhausts memory on CI runners and the
+# processes get killed, silently producing no output.
+$results = $targets | ForEach-Object -ThrottleLimit 2 -Parallel {
+  # Parallel runspaces do not reliably inherit the caller's location.
+  Set-Location $using:currentDir
+  $t = $_
+
+  if ($t.Type -eq "Slides") {
+    Write-Host "Building slides for $($t.Source)"
+    pandoc -f markdown+smart+yaml_metadata_block+rebase_relative_paths --toc --slide-level 2 --number-section --pdf-engine lualatex -t beamer -H preamble.tex -F pandoc-plantuml -o $t.Pdf $t.Source
+  }
+  else {
+    Write-Host "Building document for $($t.Source)"
+    pandoc -f markdown+smart+yaml_metadata_block+rebase_relative_paths --toc --toc-depth 1 --number-section --pdf-engine lualatex -F pandoc-plantuml -o $t.Pdf $t.Source
+  }
+
+  [PSCustomObject]@{
+    Pdf      = $t.Pdf
+    ExitCode = $LASTEXITCODE
+  }
+}
+
+# Fail the build if any PDF did not compile, instead of silently shipping a
+# partial result.
+$failed = $results | Where-Object { $_.ExitCode -ne 0 -or -not (Test-Path $_.Pdf) }
+if ($failed) {
+  Write-Host "##[error]The following PDF builds failed:"
+  $failed | ForEach-Object { Write-Host " - $($_.Pdf) (exit code $($_.ExitCode))" }
+  exit 1
+}
 
 
 
@@ -52,8 +76,13 @@ header-includes: |
   \fancyfoot[R]{Licensed under CC-BY-SA-4.0}
 ..."
   pandoc -f markdown+smart+yaml_metadata_block+rebase_relative_paths --toc --toc-depth 1 --pdf-engine lualatex -F pandoc-plantuml --title="Vorlesung Webengineering" -o "build/script.pdf" $(Get-ChildItem -Recurse -Path Material/Slides -Filter *.md)
+  $scriptExit = $LASTEXITCODE
   Remove-Item -Path "Material/Slides/99_Script.md" -Force
-  
+  if ($scriptExit -ne 0 -or -not (Test-Path "build/script.pdf")) {
+    Write-Host "##[error]Building build/script.pdf failed (exit code $scriptExit)"
+    exit 1
+  }
+
   Set-Location .\build
   Compress-Archive -Force -Path .\* -DestinationPath ..\build.zip
   Set-Location $currentDir


### PR DESCRIPTION
## Problem

The release workflow produced a green build whose `build.zip` was missing **every slide PDF** — `build/Slides/` was empty in CI even though Notes, Exercises and `script.pdf` were present. The build "worked" locally, so the failure was invisible.

Two independent causes:

1. **Silent failures.** `build.ps1` ran each `pandoc` in a `Start-Job` and never inspected the results — failed compilations were swallowed and a partial `build.zip` was shipped while the workflow stayed green.
2. **Missing beamer theme.** The slides use `theme: metropolis`. Local MiKTeX auto-installs missing packages on demand; the CI TeX Live 2024 container does not have `beamerthememetropolis.sty`, so `lualatex` aborted instantly for every slide. Notes/Exercises/`script.pdf` are article-class and were unaffected.

## Changes

- **`build.ps1`**
  - Fail the build on any `pandoc` non-zero exit or missing output file (incl. the combined `script.pdf` step) instead of zipping a partial result.
  - Capture each worker's full pandoc/LaTeX output and exit code, then print an ordered per-file status report — parallel runspaces were interleaving and swallowing the error text.
  - Throttle build concurrency and pre-create output directories in the main thread to avoid worker races.
- **`.github/workflows/create-release.yml`**
  - Add a step that pins the TeX Live 2024 historic repository and installs `beamertheme-metropolis`, `pgfopts` and `fira` before building.

## Verification

Validated on this branch (run 28223417888): `build_pdf` ✅, `create_release` correctly skipped (no release), artifact uploaded. The downloaded `build.zip` contains all 20 slide PDFs plus Notes, Exercises and `script.pdf` (8.6 MB vs the previously broken 3.8 MB).

## Follow-up (optional)

Baking `beamertheme-metropolis` + `fira` into the `pandoc-builder` image would remove the per-run `tlmgr` step and the historic-mirror dependency.
